### PR TITLE
Fix: Add encoding parameter to resolve UnicodeDecodeError

### DIFF
--- a/04.Filtering Data/1.Filter a Dataframe Based on 1 Condition.ipynb
+++ b/04.Filtering Data/1.Filter a Dataframe Based on 1 Condition.ipynb
@@ -2,8 +2,8 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "id": "acee6c9f",
+   "execution_count": null,
+   "id": "7e1b78c3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -12,14 +12,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "id": "5349f28e",
-   "metadata": {
-    "scrolled": false
-   },
+   "execution_count": null,
+   "id": "226ff072",
+   "metadata": {},
    "outputs": [],
    "source": [
-    "df_laptops = pd.read_csv('laptop_price.csv')"
+    "df_laptops = pd.read_csv('laptop_price.csv', encoding='latin1')"
    ]
   },
   {
@@ -1089,7 +1087,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "base",
    "language": "python",
    "name": "python3"
   },
@@ -1103,7 +1101,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.13.5"
   },
   "toc": {
    "base_numbering": 1,

--- a/04.Filtering Data/2.Creating a Conditional Column from 2 Choices np.where().ipynb
+++ b/04.Filtering Data/2.Creating a Conditional Column from 2 Choices np.where().ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "id": "932b054d",
    "metadata": {},
    "outputs": [],
@@ -12,19 +12,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "af2b9d82",
    "metadata": {
     "scrolled": false
    },
    "outputs": [],
    "source": [
-    "df_laptops = pd.read_csv('laptop_price.csv')"
+    "df_laptops = pd.read_csv('laptop_price.csv', encoding='latin1')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "1d57c715",
    "metadata": {
     "scrolled": true
@@ -141,7 +141,7 @@
        "2       575.00  "
       ]
      },
-     "execution_count": 3,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -160,7 +160,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "25857fac",
    "metadata": {},
    "outputs": [],
@@ -178,7 +178,7 @@
      "data": {
       "text/plain": [
        "array(['Inexpensive', 'Inexpensive', 'Inexpensive', ..., 'Inexpensive',\n",
-       "       'Inexpensive', 'Inexpensive'], dtype='<U11')"
+       "       'Inexpensive', 'Inexpensive'], shape=(1303,), dtype='<U11')"
       ]
      },
      "execution_count": 6,
@@ -389,7 +389,7 @@
        "Price_tier\n",
        "Inexpensive    1166\n",
        "Expensive       137\n",
-       "dtype: int64"
+       "Name: count, dtype: int64"
       ]
      },
      "execution_count": 9,
@@ -412,17 +412,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 10,
    "id": "875f31cc",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "array(['Small', 'Small', 'Big', ..., 'Small', 'Big', 'Big'], dtype='<U5')"
+       "array(['Small', 'Small', 'Big', ..., 'Small', 'Big', 'Big'],\n",
+       "      shape=(1303,), dtype='<U5')"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -434,7 +435,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 11,
    "id": "078b29c2",
    "metadata": {},
    "outputs": [],
@@ -445,7 +446,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 12,
    "id": "c6e3cffa",
    "metadata": {
     "scrolled": false
@@ -614,7 +615,7 @@
        "4      1803.60  Inexpensive      Small  "
       ]
      },
-     "execution_count": 16,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -626,7 +627,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 13,
    "id": "905ea459",
    "metadata": {},
    "outputs": [
@@ -636,10 +637,10 @@
        "Scren_size\n",
        "Big      835\n",
        "Small    468\n",
-       "dtype: int64"
+       "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -652,7 +653,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "base",
    "language": "python",
    "name": "python3"
   },
@@ -666,7 +667,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.13.5"
   },
   "toc": {
    "base_numbering": 1,

--- a/04.Filtering Data/3.Filter a Dataframe Based on 2 or More Conditions.ipynb
+++ b/04.Filtering Data/3.Filter a Dataframe Based on 2 or More Conditions.ipynb
@@ -12,14 +12,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "5349f28e",
    "metadata": {
     "scrolled": false
    },
    "outputs": [],
    "source": [
-    "df_laptops = pd.read_csv('laptop_price.csv')"
+    "df_laptops = pd.read_csv('laptop_price.csv', encoding='latin1')"
    ]
   },
   {
@@ -1665,7 +1665,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "base",
    "language": "python",
    "name": "python3"
   },
@@ -1679,7 +1679,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.13.5"
   },
   "toc": {
    "base_numbering": 1,

--- a/04.Filtering Data/4.Creating a Conditional Column from More Than 2 Choices np.select().ipynb
+++ b/04.Filtering Data/4.Creating a Conditional Column from More Than 2 Choices np.select().ipynb
@@ -12,14 +12,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "5349f28e",
    "metadata": {
     "scrolled": false
    },
    "outputs": [],
    "source": [
-    "df_laptops = pd.read_csv('laptop_price.csv')"
+    "df_laptops = pd.read_csv('laptop_price.csv', encoding='latin1')"
    ]
   },
   {
@@ -936,7 +936,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "base",
    "language": "python",
    "name": "python3"
   },
@@ -950,7 +950,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.13.5"
   },
   "toc": {
    "base_numbering": 1,

--- a/04.Filtering Data/5.The .isin() Method.ipynb
+++ b/04.Filtering Data/5.The .isin() Method.ipynb
@@ -12,14 +12,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "5349f28e",
    "metadata": {
     "scrolled": false
    },
    "outputs": [],
    "source": [
-    "df_laptops = pd.read_csv('laptop_price.csv')"
+    "df_laptops = pd.read_csv('laptop_price.csv', encoding='latin1')"
    ]
   },
   {

--- a/04.Filtering Data/6.Find Duplicate Rows with the .duplicated() Method.ipynb
+++ b/04.Filtering Data/6.Find Duplicate Rows with the .duplicated() Method.ipynb
@@ -12,14 +12,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "5349f28e",
    "metadata": {
     "scrolled": false
    },
    "outputs": [],
    "source": [
-    "df_laptops = pd.read_csv('laptop_price.csv')"
+    "df_laptops = pd.read_csv('laptop_price.csv', encoding='latin1')"
    ]
   },
   {

--- a/04.Filtering Data/7.Drop Duplicate Elements with the .drop_duplicates() Method.ipynb
+++ b/04.Filtering Data/7.Drop Duplicate Elements with the .drop_duplicates() Method.ipynb
@@ -12,14 +12,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "5349f28e",
    "metadata": {
     "scrolled": false
    },
    "outputs": [],
    "source": [
-    "df_laptops = pd.read_csv('laptop_price.csv')"
+    "df_laptops = pd.read_csv('laptop_price.csv', encoding='latin1')"
    ]
   },
   {

--- a/04.Filtering Data/8.Get and Count Unique Values The unique() and nunique() methods.ipynb
+++ b/04.Filtering Data/8.Get and Count Unique Values The unique() and nunique() methods.ipynb
@@ -12,14 +12,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "5349f28e",
    "metadata": {
     "scrolled": false
    },
    "outputs": [],
    "source": [
-    "df_laptops = pd.read_csv('laptop_price.csv')"
+    "df_laptops = pd.read_csv('laptop_price.csv', encoding='latin1')"
    ]
   },
   {

--- a/04.Filtering Data/Exercises/1.Exercise - Filter a Dataframe Based on 1 Condition.ipynb
+++ b/04.Filtering Data/Exercises/1.Exercise - Filter a Dataframe Based on 1 Condition.ipynb
@@ -19,7 +19,7 @@
    },
    "outputs": [],
    "source": [
-    "df_laptops = pd.read_csv('laptop_price.csv')"
+    "df_laptops = pd.read_csv('laptop_price.csv', encoding='latin1')"
    ]
   },
   {

--- a/04.Filtering Data/Exercises/2.Exercise - Creating a Conditional Column from 2 Choices np.where().ipynb
+++ b/04.Filtering Data/Exercises/2.Exercise - Creating a Conditional Column from 2 Choices np.where().ipynb
@@ -20,7 +20,7 @@
    },
    "outputs": [],
    "source": [
-    "df_laptops = pd.read_csv('laptop_price.csv')"
+    "df_laptops = pd.read_csv('laptop_price.csv', encoding='latin1')"
    ]
   },
   {

--- a/04.Filtering Data/Exercises/4.Exercise - Creating a Conditional Column from More Than 2 Choices np.select().ipynb
+++ b/04.Filtering Data/Exercises/4.Exercise - Creating a Conditional Column from More Than 2 Choices np.select().ipynb
@@ -19,7 +19,7 @@
    },
    "outputs": [],
    "source": [
-    "df_laptops = pd.read_csv('laptop_price.csv')"
+    "df_laptops = pd.read_csv('laptop_price.csv', encoding='latin1')"
    ]
   },
   {

--- a/04.Filtering Data/Exercises/7.Exercise - Drop Duplicate Elements with the .drop_duplicates() Method.ipynb
+++ b/04.Filtering Data/Exercises/7.Exercise - Drop Duplicate Elements with the .drop_duplicates() Method.ipynb
@@ -9,7 +9,17 @@
    },
    "outputs": [],
    "source": [
-    "df_laptops = pd.read_csv('laptop_price.csv')"
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "087faadb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_laptops = pd.read_csv('laptop_price.csv', encoding='latin1')"
    ]
   },
   {


### PR DESCRIPTION
## Problem
The notebook fails with `UnicodeDecodeError` when reading `laptop_price.csv` because the file contains Latin-1 encoded characters.

Fixes #2 

## Changes
- Added `encoding='latin1'` parameter to `pd.read_csv()`

## Testing
✅ Verified CSV loads successfully with the encoding parameter

## Environment
- Python 3.13